### PR TITLE
Update top-level pitch

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -44,7 +44,7 @@ const seoMetaData = {
           class="text-[1.75rem] font-[500] leading-[135%] tracking-[-0.0375rem] pb-[1.25rem]"
         >
           Fair Source is an alternative to closed source, allowing you to
-          safely sharing access to your core products. Fair Source Software
+          safely share access to your core products. Fair Source Software
           (FSS):
         </p>
         <ol

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,7 +10,7 @@ import GeoRight from '/images/background-images/geo-right.svg?raw';
 import dospImage from '../assets/about/dosp.webp';
 
 const seoMetaData = {
-  description: 'Fair Source is an alternative to closed source for safely sharing access to your core products. Fair Source Software (FSS) can be used with minimal restrictions, and becomes Open Source after a period of time.',
+  description: 'Fair Source is an alternative to closed source, allowing you to safely share access to your core products. Fair Source Software (FSS) can be used with minimal restrictions, and becomes Open Source after a period of time.',
   slug: 'about/'
 };
 
@@ -43,8 +43,9 @@ const seoMetaData = {
         <p
           class="text-[1.75rem] font-[500] leading-[135%] tracking-[-0.0375rem] pb-[1.25rem]"
         >
-          Fair Source is an alternative to closed source for safely sharing access
-          to your core products. Fair Source Software (FSS):
+          Fair Source is an alternative to closed source, allowing you to
+          safely sharing access to your core products. Fair Source Software
+          (FSS):
         </p>
         <ol
           class="text-[1.75rem] font-[500] pb-[3.25rem] pl-[3.25rem] list-decimal"
@@ -111,12 +112,12 @@ const seoMetaData = {
 
           <p class="pb-[1.5rem]">
             The purpose of Fair Source is to legitimize the practice of
-            companies meaningfully sharing access to the code for their core software
-            products while retaining control of their roadmap and business
-            model, without confusing this with Free and Open Source Software.
-            <a href="/companies/">Fair Source companies</a> value user freedom
-            and developer sustainability. Quite often, we maintain and
-            contribute both financially and in other ways to genuine
+            companies meaningfully sharing access to the code for their core
+            software products while retaining control of their roadmap and
+            business model, without confusing this with Free and Open Source
+            Software. <a href="/companies/">Fair Source companies</a> value
+            user freedom and developer sustainability. Quite often, we maintain
+            and contribute both financially and in other ways to genuine
             community-governed FOSS projects alongside our commercial Fair
             Source offerings.
           </p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,7 +10,7 @@ import GeoRight from '/images/background-images/geo-right.svg?raw';
 import dospImage from '../assets/about/dosp.webp';
 
 const seoMetaData = {
-  description: 'Fair Source Software is publicly available to read; allows use, modification, and redistribution with minimal restrictions to protect the producer’s business model; and undergoes delayed Open Source publication.',
+  description: 'Fair Source is an alternative to closed source for safely sharing access to your core products. Fair Source Software (FSS) can be used with minimal restrictions, and becomes Open Source after a period of time.',
   slug: 'about/'
 };
 
@@ -43,7 +43,8 @@ const seoMetaData = {
         <p
           class="text-[1.75rem] font-[500] leading-[135%] tracking-[-0.0375rem] pb-[1.25rem]"
         >
-          Fair Source Software (FSS):
+          Fair Source is an alternative to closed source for safely sharing access
+          to your core products. Fair Source Software (FSS):
         </p>
         <ol
           class="text-[1.75rem] font-[500] pb-[3.25rem] pl-[3.25rem] list-decimal"
@@ -110,7 +111,7 @@ const seoMetaData = {
 
           <p class="pb-[1.5rem]">
             The purpose of Fair Source is to legitimize the practice of
-            companies meaningfully sharing the code for their core software
+            companies meaningfully sharing access to the code for their core software
             products while retaining control of their roadmap and business
             model, without confusing this with Free and Open Source Software.
             <a href="/companies/">Fair Source companies</a> value user freedom

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -32,9 +32,10 @@ const seoMetaData = {
           <div class="relative flex flex-wrap">
             <div class="w-12/12 pb-[3.75rem]">
               <p>
-                Fair Source is an alternative to closed source for safely sharing
-                access to a company's core software products. The two basic features
-                of Fair Source <a href="/licenses/">licensing</a > are:
+                Fair Source is an alternative to closed source, allowing you to
+                safely sharing access to your company's core software products.
+                The two basic features of Fair Source <a href="/licenses/">licensing</a
+                > are:
               </p>
             </div>
             <div class="w-full flex flex-wrap pb-[3rem]">

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -33,7 +33,7 @@ const seoMetaData = {
             <div class="w-12/12 pb-[3.75rem]">
               <p>
                 Fair Source is an alternative to closed source, allowing you to
-                safely sharing access to your company's core software products.
+                safely share access to your company's core software products.
                 The two basic features of Fair Source <a href="/licenses/">licensing</a
                 > are:
               </p>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -32,10 +32,9 @@ const seoMetaData = {
           <div class="relative flex flex-wrap">
             <div class="w-12/12 pb-[3.75rem]">
               <p>
-                Fair Source is software sharing that is safe for companies and
-                developers alike. The two basic features of Fair Source <a
-                  href="/licenses/">licensing</a
-                > are:
+                Fair Source is an alternative to closed source for safely sharing
+                access to a company's core software products. The two basic features
+                of Fair Source <a href="/licenses/">licensing</a > are:
               </p>
             </div>
             <div class="w-full flex flex-wrap pb-[3rem]">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import fairSourceImage from '../assets/home/fairsource.png';
 import heroImage from '../assets/home/homeHeroImage.png';
 
 const seoMeta = {
-  description: 'Fair Source is software sharing for modern businesses. Engage the developer community with your core product while maintaining ownership of your roadmap and business model.',
+  description: 'Fair Source is an alternative to closed source for safely sharing access to your core products. Fair Source Software (FSS) can be used with minimal restrictions, and becomes Open Source after a period of time.',
 };
 
 const mobileSectionCommonClasses = 'z-0 pb-0 pt-[12.31rem] sm:pt-[9.12rem] sm:pb-[1.56rem] sm:px-[3rem] md:pt-[6.69rem] md:pb-[7.44rem]';
@@ -32,7 +32,7 @@ const mobileSectionContentClasses = 'z-10 pt-[1.5rem] pb-[1rem] relative w-12/12
         <h1 class="text-black mb-4">
           Software Sharing for Modern Businesses
         </h1>
-        <p class="text-balance text-black text-[1.5rem] xl:text-[2rem] leading-[130%] font-sans font-[500] mb-6">Engage the developer community with your company's core software products.</p>
+        <p class="text-balance text-black text-[1.5rem] xl:text-[2rem] leading-[130%] font-sans font-[500] mb-6">Fair Source is an alternative to closed source for safely sharing access to your core products.</p>
         <div class="flex flex-wrap gap-4">
           <Button type="primary" url='/join/' color="teal" cta="Join Fair Source" />
           <Button type="secondary" url='/about/' color="black" cta="Learn More" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import fairSourceImage from '../assets/home/fairsource.png';
 import heroImage from '../assets/home/homeHeroImage.png';
 
 const seoMeta = {
-  description: 'Fair Source is an alternative to closed source for safely sharing access to your core products. Fair Source Software (FSS) can be used with minimal restrictions, and becomes Open Source after a period of time.',
+  description: 'Fair Source is an alternative to closed source, allowing you to safely share access to your core products. Fair Source Software (FSS) can be used with minimal restrictions, and becomes Open Source after a period of time.',
 };
 
 const mobileSectionCommonClasses = 'z-0 pb-0 pt-[12.31rem] sm:pt-[9.12rem] sm:pb-[1.56rem] sm:px-[3rem] md:pt-[6.69rem] md:pb-[7.44rem]';
@@ -32,7 +32,7 @@ const mobileSectionContentClasses = 'z-10 pt-[1.5rem] pb-[1rem] relative w-12/12
         <h1 class="text-black mb-4">
           Software Sharing for Modern Businesses
         </h1>
-        <p class="text-balance text-black text-[1.5rem] xl:text-[2rem] leading-[130%] font-sans font-[500] mb-6">Fair Source is an alternative to closed source for safely sharing access to your core products.</p>
+        <p class="text-balance text-black text-[1.5rem] xl:text-[2rem] leading-[130%] font-sans font-[500] mb-6">Fair Source is an alternative to closed source, allowing you to safely share access to your core products.</p>
         <div class="flex flex-wrap gap-4">
           <Button type="primary" url='/join/' color="teal" cta="Join Fair Source" />
           <Button type="secondary" url='/about/' color="black" cta="Learn More" />


### PR DESCRIPTION
Here's a first PR aimed at making the homepage-above-the-fold messaging clearer (a big part of #35).

> Fair Source is an alternative to closed source for safely sharing access to your core products.

The idea is to anchor Fair Source **against closed source** (_not_ Open Source) from the jump, to get people comparing in a helpful vs. unhelpful direction. Also brings in the word "access" and drops "engage." And tries to be concise. :)

Does this work?

<img width="1157" alt="Screenshot 2024-08-15 at 8 07 51 AM" src="https://github.com/user-attachments/assets/275081f0-6617-4808-9344-5f18c9d7de99">
