### PR TITLE
Fixed border on FAQ

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -280,7 +280,6 @@ const seoMetaData = {
         <Collapse
           title="Is Fair Source software safe to use?"
           collapseID="is-fair-source-safe"
-          isLast
         >
           <div class="relative flex flex-wrap pb-[3rem]">
             <p>


### PR DESCRIPTION
One of the items incorrectly had the wrong border (two `isLast`).

Before:

<img width="1401" alt="image" src="https://github.com/user-attachments/assets/00c309dc-e32b-4770-8cbf-203852af7c6c">


After:

<img width="1378" alt="image" src="https://github.com/user-attachments/assets/faf62b5e-471d-4e57-ab6f-ba2a89923252">
