### PR TITLE
Remove Ptah

### DIFF
--- a/src/data/companies.json
+++ b/src/data/companies.json
@@ -7,13 +7,6 @@
     "adoption": "September 30, 2024"
   },
   {
-    "name": "ptah.sh",
-    "url": "https://ptah.sh/blog/2024-08-09-we-use-fair-source/",
-    "background": "#F1F1F3",
-    "logo": "/images/companies/ptah.sh.svg",
-    "adoption": "August 9, 2024"
-  },
-  {
     "name": "Sentry",
     "url": "https://blog.sentry.io/sentry-is-now-fair-source/",
     "background": "#362d59",


### PR DESCRIPTION
The project has been abandoned: https://github.com/ptah-sh/ptah-server (see [note](https://github.com/ptah-sh/ptah-server?tab=readme-ov-file#not-under-active-development) in README). This is a bad look for Fair Source, imo, since they're one of the first projects people see on the Fair Source home page.  If we don't want to remove the project, we should at least de-emphasize it (or create a way to mark Fair Source projects as abandoned or archived).

In the future, what do you think about requiring that companies/projects applying need to exist for X amount of time or have Y users or even Z stars before being included on the website?